### PR TITLE
Make powercord import the right file

### DIFF
--- a/powercord_manifest.json
+++ b/powercord_manifest.json
@@ -4,5 +4,5 @@
     "version": "1.0",
     "author": "Aethon#8162",
     "license": "GNU GPL",
-    "theme": "kitana.css"
+    "theme": "minimalist.css"
 }  


### PR DESCRIPTION
Currently, Powercord is trying to import a file that is not there. Therefore, when installing to the theme directory, the theme doesn't load.